### PR TITLE
Add Corporate Identification Number (CIN) Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ isValid = Validator.tan('RAJA999991');
 // isValid = false
 ```
 
+### CIN (Corporate Identification Number)
+
+A CIN is a 21-digit alphanumeric code assigned by the Registrar of Companies (RoC) to every company registered in India.
+
+#### Format
+
+- The first character is `L` or `U` (Listing status).
+- The second to sixth characters are sequential numbers running from `00001` to `99999` (Industry code).
+- The seventh and eighth characters consist of two alphabetic characters (State code).
+- The ninth to twelfth characters are numeric, representing year of incorporation.
+- The thirteenth to fifteenth characters are alphabetic, representing the type of company.
+- The sixteenth to twenty-first characters are sequential numbers running from `00001` to `99999` (Registration number).
+
+```js
+let isValid = Validator.cin('L12345MH2000PLC123456');
+// isValid = true
+
+isValid = Validator.cin('U12345BR2020PTC12A456');
+// isValid = false
+```
+
 ### UAN (Universal Account Number)
 
 A UAN is a 12 digit numberic code that is issued to member of the Employees’ Provident Fund Organisation (EPFO).

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -67,6 +67,18 @@ describe('TAN', () => {
   });
 });
 
+describe('CIN', () => {
+  const tests: [string, boolean][] = [
+    ['L12345MH2000PLC123456', true],
+    ['U12345BR2020LLC123456', true],
+    ['U12345BR2020PTC12A456', false],
+    ['H12345BR2020LLC123456', false],
+  ];
+  test.each(tests)(`Check %s => %s`, (value, expected) => {
+    expect(Validator.cin(value)).toBe(expected);
+  });
+});
+
 describe('UAN', () => {
   const tests: [string, boolean][] = [
     ['987654321098', true],

--- a/dist/validator.d.ts
+++ b/dist/validator.d.ts
@@ -4,6 +4,7 @@ export declare class Validator {
     static pincode(value: string | number): boolean;
     static pan(value: string): boolean;
     static tan(value: string): boolean;
+    static cin(value: string): boolean;
     static uan(value: string): boolean;
     static ifsc(value: string): boolean;
     static esic(value: string): boolean;

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -17,6 +17,9 @@ class Validator {
     static tan(value) {
         return /^[A-Z]{4}\d{5}[A-Z]$/i.test(value);
     }
+    static cin(value) {
+        return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value.toUpperCase());
+    }
     static uan(value) {
         return /^\d{12}$/.test(value);
     }

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -18,7 +18,7 @@ class Validator {
         return /^[A-Z]{4}\d{5}[A-Z]$/i.test(value);
     }
     static cin(value) {
-        return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value.toUpperCase());
+        return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value);
     }
     static uan(value) {
         return /^\d{12}$/.test(value);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "pincode",
     "PAN",
     "TAN",
+    "CIN",
     "UAN",
     "IFSC",
     "ESIC",

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -20,7 +20,7 @@ export class Validator {
   }
 
   static cin(value: string): boolean {
-    return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value.toUpperCase());
+    return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value);
   }
 
   static uan(value: string): boolean {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,6 +19,10 @@ export class Validator {
     return /^[A-Z]{4}\d{5}[A-Z]$/i.test(value);
   }
 
+  static cin(value: string): boolean {
+    return /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/.test(value.toUpperCase());
+  }
+
   static uan(value: string): boolean {
     return /^\d{12}$/.test(value);
   }


### PR DESCRIPTION
## Add Corporate Identification Number (CIN) Validator

### Summary

This PR adds a new validator to the `format-utils` package for verifying Indian Corporate Identification Numbers (CIN). The validator ensures that CIN input matches the official MCA-prescribed 21-character alphanumeric format.

### Why

- The package already supports validators for PAN, GSTIN, Aadhaar, etc.
- CIN is essential for any application or workflow involving Indian company compliance or onboarding.
- Enables consistent, robust validation and improves developer experience by eliminating the need for custom regex or external checks.

### CIN Format Reference

A CIN is a 21-character code structured as follows:
`L12345MH2000PLC123456`
- `L` - Listing status (L/U)
- `12345` - Industry code
- `MH` - State code
- `2000` - Year of incorporation
- `PLC` - Ownership type (e.g., PLC, UPT)
- `123456` - Registration number

### API Example

```js
let isValid = Validator.cin('L12345MH2000PLC123456'); 
// isValid = true
```

### Changes

- Adds a new `cin` function to the `Validator` utility
- Includes unit tests for valid and invalid CINs
- Updates documentation to reflect new validator

### Issue reference

closes #1782 